### PR TITLE
Add registration and login pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,3 +81,21 @@ CREATE TABLE survey_responses (
 ## Notes
 * Answers are optional; the survey saves each field after it changes.
 * Modify `.gitignore` if you use additional environment files or vendor directories.
+
+## User Accounts
+To support login and consent, create a `users` table:
+
+```sql
+CREATE TABLE users (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    username VARCHAR(50) UNIQUE,
+    first_name VARCHAR(100),
+    last_name VARCHAR(100),
+    dob DATE,
+    password_hash VARCHAR(255),
+    sec_question VARCHAR(255),
+    sec_answer VARCHAR(255)
+);
+```
+
+Access `index.php` to read about the survey, then register or login to start `survey.php`.

--- a/index.php
+++ b/index.php
@@ -1,66 +1,39 @@
 <?php
 session_start();
-if (!isset($_SESSION['session_id'])) {
-    $_SESSION['session_id'] = uniqid('resp_', true);
-}
-$session_id = $_SESSION['session_id'];
 ?>
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 <meta charset="UTF-8">
-<title>Survey</title>
-<style>
-body { font-family: Arial, sans-serif; margin: 20px; }
-form div { margin-bottom: 10px; }
-label { display: block; }
-</style>
-<script>
-var sessionId = "<?php echo $session_id; ?>";
-function saveAnswer(field, value) {
-    var formData = new FormData();
-    formData.append('session_id', sessionId);
-    formData.append('field', field);
-    formData.append('value', value);
-    fetch('save_answer.php', { method: 'POST', body: formData });
-}
-</script>
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Cobourg Helping Community Housing</title>
+<link rel="stylesheet" href="styles.css">
 </head>
 <body>
-<h1>Consent Form</h1>
-<p>Please indicate your consent to participate in this survey.</p>
-<label><input type="checkbox" id="consent"> I consent to participate in this survey.</label>
-<div id="survey" style="display:none;">
-<form id="surveyForm">
-<div>
-<label>Age: <input type="number" name="age" onchange="saveAnswer('age', this.value)"></label>
+<div class="container">
+<h1>Cobourg Helping Community Housing</h1>
+<p>Supporting individuals experiencing housing insecurities through compassion, understanding, and action.</p>
+<a href="login.php" class="btn">Login to Continue</a>
+<section class="intro">
+<h2>Share Your Voice, Shape Our Support</h2>
+<p>Your experiences matter. By completing our survey, you will help us understand your needs better and improve how we advocate and support you and others in similar situations.</p>
+<p class="notice"><strong>Mature Content Notice:</strong> This survey contains questions about sensitive topics including mental health, substance use, trauma history, and personal experiences. We respect your privacy and treat all responses as strictly confidential: you can opt to participate anonymously—no name, date of birth, or registration details are required if you select “Anonymous” on the consent form. Feel free to skip any question you’re not comfortable answering.</p>
+<p>Please login or register to access the survey.</p>
+</section>
+<section class="help">
+<h3>How We Help</h3>
+<ul>
+<li>Referral to Emergency shelter services</li>
+<li>Housing support knowledge and referrals</li>
+<li>Connections to mental health resources</li>
+<li>Substance use support and harm reduction</li>
+<li>Food Bank assistance</li>
+<li>Personal identification assistance</li>
+<li>Employment guidance and training by referrals</li>
+</ul>
+</section>
+<p class="center">Ready to Begin?</p>
+<a href="register.php" class="btn">Login/Register to Start Survey</a>
 </div>
-<div>
-<label>Gender:
-<select name="gender" onchange="saveAnswer('gender', this.value)">
-<option value="">--select--</option>
-<option value="male">Male</option>
-<option value="female">Female</option>
-<option value="other">Other</option>
-</select>
-</label>
-</div>
-<div>
-<label>Self-described gender: <input type="text" name="gender_self" onchange="saveAnswer('gender_self', this.value)"></label>
-</div>
-<?php for ($i=1; $i<=56; $i++): ?>
-<div>
-<label>Question <?php echo $i; ?>:
-<input type="text" name="q<?php echo $i; ?>" onchange="saveAnswer('q<?php echo $i; ?>', this.value)">
-</label>
-</div>
-<?php endfor; ?>
-</form>
-</div>
-<script>
-document.getElementById('consent').addEventListener('change', function() {
-    document.getElementById('survey').style.display = this.checked ? 'block' : 'none';
-});
-</script>
 </body>
 </html>

--- a/login.php
+++ b/login.php
@@ -1,0 +1,53 @@
+<?php
+session_start();
+require 'config.php';
+$err = '';
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $uname = $_POST['username'] ?? '';
+    $pass = $_POST['password'] ?? '';
+    $mysqli = new mysqli(DB_HOST, DB_USER, DB_PASS, DB_NAME);
+    if ($mysqli->connect_errno) {
+        $err = 'Database connection failed';
+    } else {
+        $stmt = $mysqli->prepare('SELECT id, password_hash FROM users WHERE username=?');
+        $stmt->bind_param('s', $uname);
+        $stmt->execute();
+        $stmt->store_result();
+        if ($stmt->num_rows === 1) {
+            $stmt->bind_result($uid, $hash);
+            $stmt->fetch();
+            if (password_verify($pass, $hash)) {
+                session_regenerate_id(true);
+                $_SESSION['user_id'] = $uname;
+                header('Location: survey.php');
+                exit;
+            }
+        }
+        $err = 'Invalid credentials';
+        $stmt->close();
+    }
+}
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Login</title>
+<link rel="stylesheet" href="styles.css">
+</head>
+<body>
+<div class="container">
+<h1>Login</h1>
+<?php if ($err): ?>
+<p class="errors"><?php echo htmlspecialchars($err); ?></p>
+<?php endif; ?>
+<form method="post">
+<label>Username <input type="text" name="username" required></label>
+<label>Password <input type="password" name="password" required></label>
+<button type="submit" class="btn">Login</button>
+</form>
+<p><a href="register.php">Need to register?</a></p>
+</div>
+</body>
+</html>

--- a/logout.php
+++ b/logout.php
@@ -3,4 +3,4 @@ session_start();
 $_SESSION = [];
 session_destroy();
 header('Location: index.php');
-
+exit();

--- a/logout.php
+++ b/logout.php
@@ -1,0 +1,6 @@
+<?php
+session_start();
+$_SESSION = [];
+session_destroy();
+header('Location: index.php');
+

--- a/register.php
+++ b/register.php
@@ -1,0 +1,136 @@
+<?php
+session_start();
+require 'config.php';
+$errors = [];
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $action = $_POST['action'] ?? '';
+    $mysqli = new mysqli(DB_HOST, DB_USER, DB_PASS, DB_NAME);
+    if ($mysqli->connect_errno) {
+        $errors[] = 'Database connection failed';
+    } else {
+        if ($action === 'anon') {
+            $_SESSION['user_id'] = 'anon';
+            header('Location: survey.php');
+            exit;
+        } elseif ($action === 'initials') {
+            $fi = strtoupper(substr(trim($_POST['first_initial'] ?? ''),0,1));
+            $li = strtoupper(substr(trim($_POST['last_initial'] ?? ''),0,1));
+            if (!$fi || !$li) {
+                $errors[] = 'Please provide initials';
+            } else {
+                $_SESSION['user_id'] = $fi.$li;
+                header('Location: survey.php');
+                exit;
+            }
+        } elseif ($action === 'register') {
+            $fname = trim($_POST['fname'] ?? '');
+            $lname = trim($_POST['lname'] ?? '');
+            $dob = trim($_POST['dob'] ?? '');
+            $question = trim($_POST['sec_question'] ?? '');
+            $answer = trim($_POST['sec_answer'] ?? '');
+            $pass = $_POST['password'] ?? '';
+            $pass2 = $_POST['password_confirm'] ?? '';
+            if (!$fname || !$lname || !$dob || !$question || !$answer || !$pass) {
+                $errors[] = 'All fields required';
+            } elseif ($pass !== $pass2) {
+                $errors[] = 'Passwords do not match';
+            } else {
+                $uname = strtoupper(substr($fname,0,3).substr($lname,0,3));
+                if (preg_match('/^(\d{4})-\d{2}-\d{2}$/', $dob, $m)) {
+                    $uname .= substr($m[1],-2);
+                } else {
+                    $errors[] = 'Invalid date format';
+                }
+                if (!$errors) {
+                    $stmt = $mysqli->prepare('SELECT id FROM users WHERE username=?');
+                    $stmt->bind_param('s', $uname);
+                    $stmt->execute();
+                    $stmt->store_result();
+                    if ($stmt->num_rows > 0) {
+                        $errors[] = 'Username already exists';
+                    } else {
+                        $hash = password_hash($pass, PASSWORD_DEFAULT);
+                        $ins = $mysqli->prepare('INSERT INTO users (username, first_name, last_name, dob, password_hash, sec_question, sec_answer) VALUES (?,?,?,?,?,?,?)');
+                        $ins->bind_param('sssssss', $uname, $fname, $lname, $dob, $hash, $question, $answer);
+                        if ($ins->execute()) {
+                            $_SESSION['user_id'] = $uname;
+                            header('Location: survey.php');
+                            exit;
+                        } else {
+                            $errors[] = 'Failed to create account';
+                        }
+                        $ins->close();
+                    }
+                    $stmt->close();
+                }
+            }
+        }
+    }
+}
+$questions = [
+    'What was your childhood nickname?',
+    'What is the name of your favorite childhood friend?',
+    'In what city or town did your parents meet?',
+    'What was the make of your first car?',
+    'What was the name of your first pet?',
+    'What is your mother\'s maiden name?',
+    'What was the name of your elementary school?',
+    'What is the name of the street you grew up on?',
+    'What is your favorite book?',
+    'What is your favorite food?'
+];
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Register / Consent</title>
+<link rel="stylesheet" href="styles.css">
+</head>
+<body>
+<div class="container">
+<h1>Participant Consent</h1>
+<?php if ($errors): ?>
+    <div class="errors">
+        <ul>
+        <?php foreach ($errors as $e): ?>
+            <li><?php echo htmlspecialchars($e); ?></li>
+        <?php endforeach; ?>
+        </ul>
+    </div>
+<?php endif; ?>
+<h2>Anonymous</h2>
+<form method="post">
+    <input type="hidden" name="action" value="anon">
+    <button type="submit" class="btn">Continue Anonymously</button>
+</form>
+<h2>Initials Only</h2>
+<form method="post">
+    <input type="hidden" name="action" value="initials">
+    <label>First Initial <input type="text" name="first_initial" maxlength="1"></label>
+    <label>Last Initial <input type="text" name="last_initial" maxlength="1"></label>
+    <button type="submit" class="btn">Continue</button>
+</form>
+<h2>Register with Full Details</h2>
+<form method="post">
+    <input type="hidden" name="action" value="register">
+    <label>First Name <input type="text" name="fname" required></label>
+    <label>Last Name <input type="text" name="lname" required></label>
+    <label>Date of Birth <input type="date" name="dob" required></label>
+    <label>Security Question
+        <select name="sec_question" required>
+            <?php foreach ($questions as $q): ?>
+            <option value="<?php echo htmlspecialchars($q); ?>"><?php echo htmlspecialchars($q); ?></option>
+            <?php endforeach; ?>
+        </select>
+    </label>
+    <label>Security Answer <input type="text" name="sec_answer" required></label>
+    <label>Password <input type="password" name="password" required></label>
+    <label>Confirm Password <input type="password" name="password_confirm" required></label>
+    <button type="submit" class="btn">Register and Start Survey</button>
+</form>
+<p><a href="login.php">Already have an account? Login</a></p>
+</div>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,9 @@
+body { font-family: Arial, sans-serif; margin: 0; padding: 0; }
+.container { max-width: 800px; margin: auto; padding: 20px; }
+.btn { display: inline-block; padding: 10px 20px; background:#0069d9; color:#fff; text-decoration:none; border-radius:4px; }
+.btn:hover { background:#0053ba; }
+.errors { color: red; }
+ul { padding-left:20px; }
+@media (max-width:600px) {
+    .container { padding: 10px; }
+}

--- a/survey.php
+++ b/survey.php
@@ -1,0 +1,69 @@
+<?php
+session_start();
+if (!isset($_SESSION['user_id'])) {
+    header('Location: login.php');
+    exit;
+}
+if (!isset($_SESSION['session_id'])) {
+    $_SESSION['session_id'] = uniqid('resp_', true);
+}
+$session_id = $_SESSION['session_id'];
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Survey</title>
+<link rel="stylesheet" href="styles.css">
+<script>
+var sessionId = "<?php echo $session_id; ?>";
+function saveAnswer(field, value) {
+    var formData = new FormData();
+    formData.append('session_id', sessionId);
+    formData.append('field', field);
+    formData.append('value', value);
+    fetch('save_answer.php', { method: 'POST', body: formData });
+}
+</script>
+</head>
+<body>
+<div class="container">
+<h1>Survey</h1>
+<p>Please indicate your consent to participate in this survey.</p>
+<label><input type="checkbox" id="consent"> I consent to participate in this survey.</label>
+<div id="survey" style="display:none;">
+<form id="surveyForm">
+<div>
+<label>Age: <input type="number" name="age" onchange="saveAnswer('age', this.value)"></label>
+</div>
+<div>
+<label>Gender:
+<select name="gender" onchange="saveAnswer('gender', this.value)">
+<option value="">--select--</option>
+<option value="male">Male</option>
+<option value="female">Female</option>
+<option value="other">Other</option>
+</select>
+</label>
+</div>
+<div>
+<label>Self-described gender: <input type="text" name="gender_self" onchange="saveAnswer('gender_self', this.value)"></label>
+</div>
+<?php for ($i=1; $i<=56; $i++): ?>
+<div>
+<label>Question <?php echo $i; ?>:
+<input type="text" name="q<?php echo $i; ?>" onchange="saveAnswer('q<?php echo $i; ?>', this.value)">
+</label>
+</div>
+<?php endfor; ?>
+</form>
+</div>
+</div>
+<script>
+document.getElementById('consent').addEventListener('change', function() {
+    document.getElementById('survey').style.display = this.checked ? 'block' : 'none';
+});
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add mobile-friendly homepage describing the survey
- implement registration with anonymous, initials, or full account options
- implement login, logout and survey access
- include simple responsive CSS
- document user table setup in README

## Testing
- `composer --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68437170c1e4832e81dbf950961e6e5c